### PR TITLE
Fix nil pointer panic on empty docker auth

### DIFF
--- a/plugin/triton_test.go
+++ b/plugin/triton_test.go
@@ -20,9 +20,14 @@ func TestDockerDriver_AuthFromTaskConfig(t *testing.T) {
 		Desc       string
 	}{
 		{
-			Auth:       types.DockerAuth{},
-			AuthConfig: nil,
-			Desc:       "Empty Config",
+			Auth: types.DockerAuth{},
+			AuthConfig: &docker.AuthConfiguration{
+				Username:      "",
+				Password:      "",
+				Email:         "",
+				ServerAddress: "",
+			},
+			Desc: "Empty Config",
 		},
 		{
 			Auth: types.DockerAuth{

--- a/plugin/utils.go
+++ b/plugin/utils.go
@@ -21,7 +21,12 @@ func authFromTaskConfig(tc types.TaskConfig) authBackend {
 	return func(string) (*docker.AuthConfiguration, error) {
 		// If all auth fields are empty, return
 		if len(tc.Docker.Auth.Username) == 0 && len(tc.Docker.Auth.Password) == 0 && len(tc.Docker.Auth.Email) == 0 && len(tc.Docker.Auth.ServerAddr) == 0 {
-			return nil, nil
+			return &docker.AuthConfiguration{
+				Username:      "",
+				Password:      "",
+				Email:         "",
+				ServerAddress: "",
+			}, nil
 		}
 		return &docker.AuthConfiguration{
 			Username:      tc.Docker.Auth.Username,
@@ -30,15 +35,4 @@ func authFromTaskConfig(tc types.TaskConfig) authBackend {
 			ServerAddress: tc.Docker.Auth.ServerAddr,
 		}, nil
 	}
-}
-
-// authIsEmpty returns if auth is nil or an empty structure
-func authIsEmpty(auth *docker.AuthConfiguration) bool {
-	if auth == nil {
-		return false
-	}
-	return auth.Username == "" &&
-		auth.Password == "" &&
-		auth.Email == "" &&
-		auth.ServerAddress == ""
 }


### PR DESCRIPTION
Backported the fix https://github.com/teutat3s/nomad-triton-driver-plugin/commit/295665b6d489acb672c44118f5e81a87f4b3f61e from the new driver repo to leave a working codebase here, too.